### PR TITLE
:memo: Update main `index.html`

### DIFF
--- a/source/documentation/runbooks/index.html.md.erb
+++ b/source/documentation/runbooks/index.html.md.erb
@@ -7,6 +7,6 @@ review_in: 3 months
 
 # <%= current_page.data.title %>
 
-List of Runbooks
+List of Runbooks:
 
-- [Ingestion Maintenance](/documentation/runbooks/001-ingestion-maintenance.html)
+### [Ingestion Maintenance](/documentation/runbooks/001-ingestion-maintenance.html)

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -12,20 +12,15 @@ This site contains internal documentation for the Ministry of Justice's Analytic
 
 If you are a user of the Analytical Platform, please see our [User Guidance](https://user-guidance.analytical-platform.service.justice.gov.uk/).
 
-## Introduction
+## Runbooks
 
-We are the Analytical Platform team, a multidisciplinary group formed of data, platform and software engineers. Our primary focus is building the Analytical Platform, which provides data analysis and data warehouse capabilities to the Ministry of Justice.
+Runbooks are located [here](/documentation/runbooks/index.html).
 
-## Our Mission
+## Guidance
 
-Offer frictionless access to data for exploitation and visualisation, to drive decision making.
+- [Joining Our Team](https://technical-documentation.data-platform.service.justice.gov.uk/documentation/team/joining-our-teams.html#joining-our-teams)
+- [Ways of Working](https://technical-documentation.data-platform.service.justice.gov.uk/documentation/team/ways-of-working.html)
 
 ## Who Are We?
 
 Find our team on [MoJ People Finder](https://peoplefinder.service.gov.uk/teams/analytical-platform).
-
-## Guidance
-
-- [Joining Our Team](/documentation/joining-our-team/index.html)
-- [Ways of Working](/documentation/ways-of-working/index.html)
-- [Runbooks](/documentation/runbooks/index.html)


### PR DESCRIPTION
This PR updates the structure of the landing page. The previous information was redundant for the internal audience of the runbooks and having this in two places would mean it would have to be updated twice if needed. 
<img width="1377" alt="Screenshot 2024-03-26 at 09 18 02" src="https://github.com/ministryofjustice/analytical-platform-runbooks/assets/26419401/b405894d-8874-4265-912e-d004ee18a4b7">

Additionally this updates the runbooks to use headings so they appear in the side bar.
<img width="1393" alt="Screenshot 2024-03-26 at 09 28 53" src="https://github.com/ministryofjustice/analytical-platform-runbooks/assets/26419401/ef7dbd8d-825e-4749-a71f-f02daacef753">
